### PR TITLE
Add defensive null checks

### DIFF
--- a/3ds2-example/backend/src/payments/payments.controller.ts
+++ b/3ds2-example/backend/src/payments/payments.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Post } from "@nestjs/common";
+import { Body, Controller, Get, Post, BadRequestException } from "@nestjs/common";
 import { PaymentsService } from "./payments.service";
 
 @Controller()
@@ -12,21 +12,33 @@ export class PaymentsController {
 
   @Post("/payments/redirect")
   postPaymentsRedirect(@Body() requestBody: any): Promise<any> {
+    if (!requestBody) {
+      throw new BadRequestException("Request body is required");
+    }
     return this.paymentService.postForPaymentsRedirect(requestBody);
   }
 
   @Post("/payments/native")
   postPaymentsNative(@Body() requestBody: any): Promise<any> {
+    if (!requestBody) {
+      throw new BadRequestException("Request body is required");
+    }
     return this.paymentService.postForPaymentsNative(requestBody);
   }
 
   @Post("/sessions")
   postSessions(@Body() requestBody: any): Promise<any> {
+    if (!requestBody || !requestBody.data) {
+      throw new BadRequestException("Request body is required");
+    }
     return this.paymentService.postForSessions(requestBody.data);
   }
 
   @Post("/paymentDetails")
   postPaymentDetails(@Body() requestBody: any): Promise<any> {
+    if (!requestBody || !requestBody.data) {
+      throw new BadRequestException("Request body is required");
+    }
     return this.paymentService.postForPaymentDetails(requestBody.data);
   }
 }

--- a/3ds2-example/backend/src/payments/payments.service.spec.ts
+++ b/3ds2-example/backend/src/payments/payments.service.spec.ts
@@ -1,0 +1,38 @@
+import { PaymentsService } from './payments.service';
+import { ConfigService } from '@nestjs/config';
+
+describe('PaymentsService validation', () => {
+  let service: PaymentsService;
+
+  beforeEach(() => {
+    const configService = {
+      get: jest.fn().mockReturnValue('test'),
+    } as unknown as ConfigService;
+    service = new PaymentsService(configService);
+    // stub out API calls
+    service.paymentsAPI = {
+      payments: jest.fn(),
+      paymentsDetails: jest.fn(),
+      sessions: jest.fn(),
+      paymentMethods: jest.fn(),
+    } as any;
+  });
+
+  it('postForPaymentsNative throws when data is missing', async () => {
+    await expect(
+      service.postForPaymentsNative({ data: null as any, url: 'http://example.com' })
+    ).rejects.toThrow('Payment data is required');
+  });
+
+  it('postForPaymentsRedirect throws when url is missing', async () => {
+    await expect(
+      service.postForPaymentsRedirect({ data: { paymentMethod: {}, browserInfo: {} }, url: undefined as any })
+    ).rejects.toThrow('Return URL is required');
+  });
+
+  it('postForSessions throws when url is falsy', async () => {
+    await expect(
+      service.postForSessions({ url: undefined as any })
+    ).rejects.toThrow('Return URL is required');
+  });
+});

--- a/3ds2-example/backend/src/payments/payments.service.ts
+++ b/3ds2-example/backend/src/payments/payments.service.ts
@@ -7,6 +7,7 @@ import { Injectable } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { v4 as uuid } from "uuid";
 import { Client, CheckoutAPI } from "@adyen/api-library";
+import { assertDefined } from "../utils/validators";
 import {
   PaymentMethodsResponse,
   PaymentResponse,
@@ -94,6 +95,11 @@ export class PaymentsService {
    * @returns PaymentResponse
    */
   async postForPaymentsNative({ data, url }): Promise<PaymentResponse> {
+    assertDefined(data, "Payment data is required");
+    assertDefined(data.paymentMethod, "paymentMethod is required");
+    assertDefined(data.browserInfo, "browserInfo is required");
+    assertDefined(url, "Return URL is required");
+
     const reference = uuid(); // generate a unique reference id
 
     const authenticationData: AuthenticationData = {
@@ -181,6 +187,11 @@ export class PaymentsService {
    * @returns PaymentResponse
    */
   async postForPaymentsRedirect({ data, url }): Promise<PaymentResponse> {
+    assertDefined(data, "Payment data is required");
+    assertDefined(data.paymentMethod, "paymentMethod is required");
+    assertDefined(data.browserInfo, "browserInfo is required");
+    assertDefined(url, "Return URL is required");
+
     const reference = uuid(); // generate a unique reference id
 
     const paymentRequestData: PaymentRequest = {
@@ -235,6 +246,7 @@ export class PaymentsService {
    * @returns PaymentDetailsResponse
    */
   async postForPaymentDetails({ details }: { details: PaymentCompletionDetails }): Promise<PaymentDetailsResponse> {
+    assertDefined(details, "payment details are required");
     const paymentDetailsResponse: PaymentDetailsResponse = await this.paymentsAPI.paymentsDetails({ details });
 
     return paymentDetailsResponse;
@@ -275,6 +287,7 @@ export class PaymentsService {
    * @returns CreateCheckoutSessionResponse
    */
   async postForSessions({ url }): Promise<CreateCheckoutSessionResponse> {
+    assertDefined(url, "Return URL is required");
     const reference = uuid(); // generate a unique reference id
 
     const sessionsRequestData: CreateCheckoutSessionRequest = {

--- a/3ds2-example/backend/src/utils/validators.ts
+++ b/3ds2-example/backend/src/utils/validators.ts
@@ -1,0 +1,10 @@
+export function assertDefined<T>(value: T | null | undefined, message: string): T {
+  if (value === null || value === undefined) {
+    throw new Error(message);
+  }
+  return value;
+}
+
+export function isNullOrUndefined(value: unknown): boolean {
+  return value === null || value === undefined;
+}

--- a/3ds2-example/backend/tsconfig.json
+++ b/3ds2-example/backend/tsconfig.json
@@ -12,7 +12,7 @@
     "baseUrl": "./",
     "incremental": true,
     "skipLibCheck": true,
-    "strictNullChecks": false,
+    "strictNullChecks": true,
     "noImplicitAny": false,
     "strictBindCallApply": false,
     "forceConsistentCasingInFileNames": false,


### PR DESCRIPTION
## Summary
- validate request bodies in payment controller
- add null checks in payment service
- add utility helpers for validation
- enable TypeScript strictNullChecks
- test falsy input handling

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68668158b4a88323b7f0be120e7524dc